### PR TITLE
Add hotkeys for forward and back

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,6 +41,15 @@ function setKeyHandling() {
         let newFullscreenMode = !currentWindow.isFullScreen();
         currentWindow.setFullScreen(newFullscreenMode);
     });
+    globalShortcut.register('CommandOrControl+Alt+Shift+Left', () => {
+        let currentWindow = BrowserWindow.getFocusedWindow();
+        currentWindow.webContents.goBack();
+    });
+    globalShortcut.register('CommandOrControl+Alt+Shift+Right', () => {
+        let currentWindow = BrowserWindow.getFocusedWindow();
+        currentWindow.webContents.goForward();
+    });
+    
 }
 
 function createTray(mainWindow) {


### PR DESCRIPTION
If you somehow get off the GeForce NOW page you couldn't get back, so I added ctrl+alt+shift left for back and ctrl+alt+shift right for forward. Hopefully no one uses those in a game.